### PR TITLE
fix: remove output when deleting a potentially existing workspace

### DIFF
--- a/bin/geoserver.fn.sh
+++ b/bin/geoserver.fn.sh
@@ -359,7 +359,7 @@ create_workspace() {
     # Make sure the workspace doesn't exist:
     # (also make sure this won't fail when the workspace does not exist yet)
 
-    curl -4 --silent --fail --show-error --request DELETE \
+    curl -4 --silent --fail --request DELETE \
         "${url}/rest/workspaces/${GEOSERVER_WORKSPACE_NAME}?recurse=true" \
         --user "${user}":"${pass}" \
         || true


### PR DESCRIPTION
When trying to delete the first workspace, curl's `--show-error` flag makes it output an undesirable error.
Let's remove this flag so we (very) silently fail if the workspace we try to delete doesn't exist.