### PR TITLE
fix: depend on java-war-buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,12 +135,12 @@ Defaults to `/app/geoserver-data`
 #### `JAVA_VERSION`
 
 Java Runtime Environment to use to run GeoServer.\
-Defaults to `11`
+Defaults to: see [java-war-buildpack](https://github.com/Scalingo/java-war-buildpack#java_version)
 
 #### `JAVA_WEBAPP_RUNNER_VERSION`
 
 Version of webapp runner to install and use.\
-Defaults to `9.0.52.1`
+Defaults to: see [java-war-buildpack](https://github.com/Scalingo/java-war-buildpack#java_webapp_runner_version)
 
 
 ## Requirements

--- a/bin/compile
+++ b/bin/compile
@@ -7,11 +7,12 @@ then
     set -x
 fi
 
-readonly build_dir="${1}"
-readonly cache_dir="${2}"
+readonly BUILD_DIR="${1}"
+readonly CACHE_DIR="${2}"
+readonly ENV_DIR="${3}"
 
-readonly base_dir="$( cd -P "$( dirname "$0" )" && pwd )"
-readonly buildpack_dir="$( readlink -f "${base_dir}/.." )"
+readonly BASE_DIR="$( cd -P "$( dirname "$0" )" && pwd )"
+readonly BUILDPACK_DIR="$( readlink -f "${BASE_DIR}/.." )"
 
 
 
@@ -23,15 +24,15 @@ readonly geoserver_config_script="${GEOSERVER_CONFIG_SCRIPT:-/app/configure-geos
 readonly geoserver_config_dir="${GEOSERVER_CONFIG_DIR:-${HOME}/geoserver}"
 readonly geoserver_data_dir="${GEOSERVER_DATA_DIR:-/app/geoserver-data}"
 
-readonly config_script="${geoserver_config_script//\/app/$build_dir}"
-readonly data_dir="${geoserver_data_dir//\/app/$build_dir}"
+readonly config_script="${geoserver_config_script//\/app/$BUILD_DIR}"
+readonly data_dir="${geoserver_data_dir//\/app/$BUILD_DIR}"
 
 JAVA_VERSION="${JAVA_VERSION:-11}"
 export JAVA_VERSION
 
 
 # "Include" functions:
-source "${buildpack_dir}/bin/geoserver.fn.sh"
+source "${BUILDPACK_DIR}/bin/geoserver.fn.sh"
 
 
 check_environment
@@ -40,10 +41,10 @@ echo "---> Running with:"
 print_environment
 
 echo "---> Installing JRE ${java_version}"
-install_java_webapp_runner "${build_dir}" "${cache_dir}" "${env_dir}"
+install_java_webapp_runner "${BUILD_DIR}" "${CACHE_DIR}" "${ENV_DIR}"
 
 
-get_geoserver "${build_dir}" "${cache_dir}" "${geoserver_version}"
+get_geoserver "${BUILD_DIR}" "${CACHE_DIR}" "${geoserver_version}"
 
 
 # Make sure GeoServer data directory exists:
@@ -60,7 +61,7 @@ readonly temp_host="http://localhost:${temp_port}"
 GEOSERVER_DATA_DIR="${data_dir}"
 export GEOSERVER_DATA_DIR
 
-run_geoserver "${build_dir}" "${temp_port}"
+run_geoserver "${BUILD_DIR}" "${temp_port}"
 readonly geoserver_pid="${!}"
 
 if [ -n "${geoserver_pid}" ]
@@ -75,7 +76,7 @@ then
     while IFS= read -r -d '' file
     do
         do_template "${file}"
-    done < <( find "${buildpack_dir}/config" -name "*.erb" -print0 )
+    done < <( find "${BUILDPACK_DIR}/config" -name "*.erb" -print0 )
 
     while IFS= read -r -d '' file
     do
@@ -88,11 +89,11 @@ then
     readonly default_pass="geoserver"
 
     echo "---> Creating ${GEOSERVER_WORKSPACE_NAME} workspace"
-    create_workspace "${buildpack_dir}" "${temp_host}" \
+    create_workspace "${BUILDPACK_DIR}" "${temp_host}" \
         "${default_user}" "${default_pass}"
 
     echo "---> Creating ${GEOSERVER_DATASTORE_NAME} datastore"
-    create_datastore "${buildpack_dir}" "${temp_host}" \
+    create_datastore "${BUILDPACK_DIR}" "${temp_host}" \
         "${default_user}" "${default_pass}"
 
 
@@ -105,17 +106,17 @@ then
 
 
     echo "---> Enforcing GeoWebCache disk quota"
-    enforce_geowebcache_diskquota "${buildpack_dir}"
+    enforce_geowebcache_diskquota "${BUILDPACK_DIR}"
 
     echo "---> Enforcing logging to stdout"
-    enforce_logging_to_stdout "${buildpack_dir}" "${temp_host}" \
+    enforce_logging_to_stdout "${BUILDPACK_DIR}" "${temp_host}" \
         "${default_user}" "${default_pass}"
 
     echo "---> Removing master password info file"
     remove_masterpw
 
     echo "---> Setting admin user account password"
-    set_admin_password "${buildpack_dir}" "${temp_host}" \
+    set_admin_password "${BUILDPACK_DIR}" "${temp_host}" \
         "${default_user}" "${default_pass}"
 
 
@@ -129,8 +130,8 @@ fi
 
 
 # Copy startup script:
-mkdir -p "${build_dir}/bin"
-cp "${buildpack_dir}/bin/startup.sh" "${build_dir}/bin/"
+mkdir -p "${BUILD_DIR}/bin"
+cp "${BUILDPACK_DIR}/bin/startup.sh" "${BUILD_DIR}/bin/"
 
 
 # Leaving the BUILD phase, setting `GEOSERVER_DATA_DIR` back to its

--- a/bin/compile
+++ b/bin/compile
@@ -140,7 +140,7 @@ GEOSERVER_DATA_DIR="${geoserver_data_dir}"
 export GEOSERVER_DATA_DIR
 
 # Make sure GEOSERVER_DATA_DIR is exported when RUNning:
-cat > "${build_dir}/.profile.d/geoserver.sh" << EOF
+cat > "${BUILD_DIR}/.profile.d/geoserver.sh" << EOF
 export GEOSERVER_DATA_DIR="${geoserver_data_dir}"
 EOF
 

--- a/bin/compile
+++ b/bin/compile
@@ -26,8 +26,8 @@ readonly geoserver_data_dir="${GEOSERVER_DATA_DIR:-/app/geoserver-data}"
 readonly config_script="${geoserver_config_script//\/app/$build_dir}"
 readonly data_dir="${geoserver_data_dir//\/app/$build_dir}"
 
-readonly java_version="${JAVA_VERSION:-11}"
-readonly webapp_runner_version="${JAVA_WEBAPP_RUNNER_VERSION:-9.0.52.1}"
+JAVA_VERSION="${JAVA_VERSION:-11}"
+export JAVA_VERSION
 
 
 # "Include" functions:
@@ -40,12 +40,7 @@ echo "---> Running with:"
 print_environment
 
 echo "---> Installing JRE ${java_version}"
-install_webapp_runner "${build_dir}" "${cache_dir}" \
-    "${java_version}" "${webapp_runner_version}" \
-    || {
-        echo "!! Unable to install JRE. Aborting." >&2
-        exit 1
-    }
+install_java_webapp_runner "${build_dir}" "${cache_dir}" "${env_dir}"
 
 
 get_geoserver "${build_dir}" "${cache_dir}" "${geoserver_version}"
@@ -71,7 +66,7 @@ readonly geoserver_pid="${!}"
 if [ -n "${geoserver_pid}" ]
 then
     echo "---> Started temporary GeoServer on ${temp_host} (pid: ${geoserver_pid})"
-    curl --silent --retry 6 --retry-connrefused --retry-delay 0 -4 \
+    curl --silent --retry 8 --retry-connrefused -4 \
         "${temp_host}"
 
     echo "---> Processing configuration templates"
@@ -140,7 +135,8 @@ cp "${buildpack_dir}/bin/startup.sh" "${build_dir}/bin/"
 
 # Leaving the BUILD phase, setting `GEOSERVER_DATA_DIR` back to its
 # initial value.
-export GEOSERVER_DATA_DIR="${geoserver_data_dir}"
+GEOSERVER_DATA_DIR="${geoserver_data_dir}"
+export GEOSERVER_DATA_DIR
 
 # Make sure GEOSERVER_DATA_DIR is exported when RUNning:
 cat > "${build_dir}/.profile.d/geoserver.sh" << EOF

--- a/bin/geoserver.fn.sh
+++ b/bin/geoserver.fn.sh
@@ -95,15 +95,15 @@ stop_geoserver() {
 # Usage: install_java_webapp_runner <build_dir> <cache_dir> <env_dir>
 #
 install_java_webapp_runner() {
-    local b_dir
-    local c_dir
+    local build_dir
+    local cache_dir
     local e_dir
 
     local java_war_buildpack_url
     local java_war_buildpack_dir
 
-    b_dir="${1}"
-    c_dir="${2}"
+    build_dir="${1}"
+    cache_dir="${2}"
     e_dir="${3}"
 
     java_war_buildpack_url="https://github.com/Scalingo/java-war-buildpack.git"
@@ -116,14 +116,14 @@ install_java_webapp_runner() {
     git clone --depth=1 "${java_war_buildpack_url}" "${java_war_buildpack_dir}"
 
     # And call it:
-    "${java_war_buildpack_dir}/bin/compile" "${b_dir}" "${c_dir}" "${e_dir}"
+    "${java_war_buildpack_dir}/bin/compile" "${build_dir}" "${cache_dir}" "${e_dir}"
 
     # Cleanup:
     rm -Rf "${java_war_buildpack_dir}"
 
     # If the java-war-buildpack left an export file behind, let's source it:
-    if [ -e "${b_dir}/export" ]; then
-        source "${b_dir}/export"
+    if [ -e "${build_dir}/export" ]; then
+        source "${build_dir}/export"
     fi
 }
 

--- a/bin/geoserver.fn.sh
+++ b/bin/geoserver.fn.sh
@@ -122,9 +122,10 @@ install_java_webapp_runner() {
     # Cleanup:
     rm -Rf "${java_war_buildpack_dir}"
 
-    # If the java-war-buildpack left an export file behind, let's source it:
-    if [ -e "${build_dir}/export" ]; then
-        source "${build_dir}/export"
+    # The java-war-buildpack leaves an `export` file in `$( pwd )`.
+    # Let's source it:
+    if [ -e "./export" ]; then
+        source "./export"
     fi
 }
 

--- a/bin/geoserver.fn.sh
+++ b/bin/geoserver.fn.sh
@@ -119,14 +119,14 @@ install_java_webapp_runner() {
     "${java_war_buildpack_dir}/bin/compile" \
         "${build_dir}" "${cache_dir}" "${env_dir}"
 
-    # Cleanup:
-    rm -Rf "${java_war_buildpack_dir}"
-
     # The java-war-buildpack leaves an `export` file in `$( pwd )`.
     # Let's source it:
     if [ -e "./export" ]; then
         source "./export"
     fi
+
+    # Cleanup:
+    rm -Rf "${java_war_buildpack_dir}"
 }
 
 


### PR DESCRIPTION
Remove duplicated code taken from the java-war-buildpack and directly use the java-war-buildpack instead.

Update the README file to point to the java-war-buildpack's README for default values of the `JAVA_VERSION` and `JAVA_WEBAPP_RUNNER_VERSION` environement variables.